### PR TITLE
Elimina codigo en mensages

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -184,7 +184,6 @@ class RecipientCreate(LoginRequiredMixin, SuccessMessageMixin,
     success_message = ugettext_lazy('Destinatario creado correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('recipient-detail', args=[self.object.id])
 
 
@@ -199,11 +198,9 @@ class RecipientEdit(LoginRequiredMixin, SuccessMessageMixin, MenuMixin, generic.
     form_class = forms.RecipientEdit
     template_name = 'webapp/recipient/edit.html'
     name = ugettext_lazy('Detalle destinatario')
-
     success_message = ugettext_lazy('Destinatario editado correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('recipient-detail', args=[self.object.id])
 
 
@@ -226,7 +223,6 @@ class VolunteerCreate(LoginRequiredMixin, SuccessMessageMixin,
     success_message = ugettext_lazy('Voluntario creado correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('volunteer-detail', args=[self.object.id])
 
 
@@ -238,7 +234,6 @@ class VolunteerEdit(LoginRequiredMixin, SuccessMessageMixin, MenuMixin, generic.
     success_message = ugettext_lazy('Voluntario editado correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('volunteer-detail', args=[self.object.id])
 
 
@@ -286,7 +281,6 @@ class MemberCreate(LoginRequiredMixin, SuccessMessageMixin, MenuMixin, FromPerso
     success_message = ugettext_lazy('Socio creado correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('member-detail', args=[self.object.id])
 
 
@@ -304,7 +298,6 @@ class MemberEdit(LoginRequiredMixin, SuccessMessageMixin, MenuMixin, generic.Upd
     success_message = ugettext_lazy('Socio editado correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('member-detail', args=[self.object.id])
 
 
@@ -388,7 +381,6 @@ class GroupEdit(LoginRequiredMixin, SuccessMessageMixin, MenuMixin, generic.Upda
     success_message = ugettext_lazy('Grupo editado correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('group-detail', args=[self.object.id])
 
 
@@ -400,5 +392,4 @@ class GroupCreate(LoginRequiredMixin, SuccessMessageMixin, MenuMixin, generic.Cr
     success_message = ugettext_lazy('Grupo creado correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('group-detail', args=[self.object.id])

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -150,7 +150,6 @@ class PersonEdit(LoginRequiredMixin, SuccessMessageMixin, MenuMixin, generic.Upd
     success_message = ugettext_lazy('Persona editada correctamente')
 
     def get_success_url(self):
-        messages.success(self.request, self.success_message)
         return reverse('person-detail', args=[self.object.id])
 
 


### PR DESCRIPTION
En el metodo de 'get_success_url' se elimina una linea de codigo que genera un mensaje, originando que salga dos veces el mensaje.